### PR TITLE
Fix double links entry in tor service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -444,7 +444,6 @@ services:
       - teddit
       - libretranslate
       - searx
-      - explorer
       - invidious
       - p2pool
       - privatebin


### PR DESCRIPTION
explorer was there twice, was unable to deploy
Fixes #14 