### PR TITLE
bumps docker-compose and traefik versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-version: '3'
+version: '3.7'
 services:
   traefik:
-    image: "traefik:v2.5"
+    image: "traefik:v2.6.1"
     container_name: "traefik"
     restart: unless-stopped
     command:


### PR DESCRIPTION
this changeset updates the `docker-compose.yml` file to `3.7` which has been tested on:

- arch linux
- debian linux
- ubuntu

additionally the changeset includes a minor and tiny version bump of `traefik` to `v2.6.1` to bring the reverse proxy container in parity with traefik-labs upstream image.  it also addresses an mtls security issue recently announced.

please review the changeset and provide feedback or present questions as they arise.