### PR TITLE
bump traefik tiny version before next release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   traefik:
-    image: "traefik:v2.6.1"
+    image: "traefik:v2.6.2"
     container_name: "traefik"
     restart: unless-stopped
     command:


### PR DESCRIPTION
this minor changeset bumps traefik tiny version to `2.6.3` which has been tested with no regressions.  i've not had the time to test `2.7` which was just cut as ga today.