### PR TITLE
Updated redisHost variable, as variable changed.

### DIFF
--- a/nitter.conf
+++ b/nitter.conf
@@ -9,7 +9,7 @@ hostname = "nitter.mydomain.com"
 [Cache]
 listMinutes = 240  # how long to cache list info (not the tweets, so keep it high)
 rssMinutes = 10  # how long to cache rss queries
-redisHost = "localhost"
+redisHost = "redis"
 redisPort = 6379
 redisConnections = 20 # connection pool size
 redisMaxConnections = 30


### PR DESCRIPTION
Variable redisHost="localhost" won't connect to redis server. Changing redisHost variable to "redis" resolves issue.